### PR TITLE
Update node-test-parser to the latest release and fix error parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,11 +73,11 @@ function formatMessage(test) {
     errorMessage += `\n\n${test.diagnostic}`
   }
 
-  if (error.stack) {
-    const cleanStack = stackUtils.clean(error.stack)
+  if (error.cause && error.cause.stack) {
+    const cleanStack = stackUtils.clean(error.cause.stack)
     errorMessage += `\n\nStack:\n\`\`\`\n${cleanStack}\`\`\`\n`
 
-    const errorLocation = findErrorLocation(error)
+    const errorLocation = findErrorLocation(error.cause)
     if (errorLocation) {
       annotateError(error, errorLocation)
     }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@actions/core": "^1.10.0",
     "error-stack-parser": "^2.1.4",
-    "node-test-parser": "github:nearform/node-test-parser#v2.0.4",
+    "node-test-parser": "github:nearform/node-test-parser#v2.1.0",
     "stack-utils": "^2.0.6"
   },
   "devDependencies": {

--- a/test/resources/expected.md
+++ b/test/resources/expected.md
@@ -38,9 +38,10 @@ TestContext.<anonymous> (file://test/resources/sample-tests/broken.test.js:5:3)
 
 Stack:
 ```
-TestContext.<anonymous> (file://test/resources/sample-tests/nested.test.js:12:16)
-async Promise.all (index 0)
-async Promise.all (index 0)
+1 !== 2
+    TestContext.<anonymous> (file://test/resources/sample-tests/nested.test.js:12:16)
+    async Promise.all (index 0)
+    async Promise.all (index 0)
 ```
 
   </blockquote>


### PR DESCRIPTION
With the latests updates of the node test runner there are some inconsistencies in reported data:

**Solution:**
- Update node-test-parser
- Fix the parsing logic of the new error object on failing tests

Resolve #106 