### PR TITLE
[Issue #186]: Ensure ts-node paths are resolved correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 import { summary, error as annotateError } from '@actions/core'
 import ErrorStackParser from 'error-stack-parser'
 import parseReport from 'node-test-parser'
+import url from 'url'
 import StackUtils from 'stack-utils'
 
 const workspace = process.env.GITHUB_WORKSPACE
@@ -118,6 +119,14 @@ function findErrorLocation(error) {
   }
 }
 
-function getRelativeFilePath(path) {
-  return new URL(path).pathname.replace(workspacePrefixRegex, '')
+export function getSafePath(path) {
+  if (path.startsWith('file')) {
+    return path
+  }
+  return url.pathToFileURL(path).href
+}
+
+export function getRelativeFilePath(path) {
+  const filePath = getSafePath(path)
+  return new URL(filePath).pathname.replace(workspacePrefixRegex, '')
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "lint": "eslint .",
     "test": "./test/e2e/compare.sh",
+    "test-package": "node --test ./test/package-tests/**.test.js",
     "prepare": "husky"
   },
   "repository": {

--- a/test/package-tests/path.test.js
+++ b/test/package-tests/path.test.js
@@ -1,0 +1,23 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+import { getRelativeFilePath, getSafePath } from '../../index.js'
+
+describe('File Path', () => {
+  it('should prefix file:// to file path', () => {
+    const expected = 'file:///path/to/file.js'
+    const actual = getSafePath('/path/to/file.js')
+    assert.equal(expected, actual)
+  })
+
+  it('should not modify correctly constructed path', () => {
+    const expected = 'file:///path/to/file.js'
+    const actual = getSafePath('file:///path/to/file.js')
+    assert.equal(expected, actual)
+  })
+
+  it('should not error with file path without file:// prefix', () => {
+    const filePath = '/path/to/file.js'
+    const actualUrl = getRelativeFilePath(filePath)
+    assert.equal(actualUrl, filePath)
+  })
+})


### PR DESCRIPTION
I've added some tests and I didn't want to interfere with the way you've setup the tests as examples so I created a new script and a new folder just for the tests for the package itself.  Let me know if you'd prefer me to do it differently - happy to change.