### PR TITLE
improve test statistics and error output

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ export default async function* githubSummaryReporter(source) {
     { data: 'Duration', header: true }
   ]
 
-  const reportDetails = testDetails(testCounters, {tests: tests})
+  const reportDetails = testDetails(testCounters, { tests: tests })
 
   const tableRow = [
     `${testCounters.passed}`,

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ export default async function* githubSummaryReporter(source) {
   const report = await parseReport(source)
   const tests = report.tests
 
-  const statistics = {
+  const testCounters = {
     passed: 0,
     failed: 0,
     skipped: 0
@@ -29,12 +29,12 @@ export default async function* githubSummaryReporter(source) {
     { data: 'Duration', header: true }
   ]
 
-  const reportDetails = testDetails(statistics, {tests: tests})
+  const reportDetails = testDetails(testCounters, {tests: tests})
 
   const tableRow = [
-    `${statistics.passed}`,
-    `${statistics.failed}`,
-    `${statistics.skipped}`,
+    `${testCounters.passed}`,
+    `${testCounters.failed}`,
+    `${testCounters.skipped}`,
     `${parseInt(report.duration)}ms`
   ]
 
@@ -48,33 +48,33 @@ export default async function* githubSummaryReporter(source) {
   yield ''
 }
 
-function testDetails(statistics, test) {
+function testDetails(testCounters, test) {
   if (!test.tests.length) {
-    return formatMessage(statistics, test)
+    return formatMessage(testCounters, test)
   }
 
   return test.tests
     .map(test =>
       formatDetails(
         `${statusEmoji(test)} ${test.name}`,
-        testDetails(statistics, test)
+        testDetails(testCounters, test)
       )
     )
     .join('\n')
 }
 
-function formatMessage(statistics, test) {
+function formatMessage(testCounters, test) {
   if (test.skip) {
-    statistics.skipped++
+    testCounters.skipped++
     return 'Test skipped'
   }
 
   const error = test.error || test.failure
   if (!error) {
-    statistics.passed++
+    testCounters.passed++
     return 'Test passed'
   }
-  statistics.failed++
+  testCounters.failed++
 
   let errorMessage = '\n\n```\n' + error.message + '\n```'
 

--- a/index.js
+++ b/index.js
@@ -14,13 +14,12 @@ const stackUtils = new StackUtils({
 
 export default async function* githubSummaryReporter(source) {
   const report = await parseReport(source)
-  const tests = report.tests;
+  const tests = report.tests
 
   const statistics = {
     passed: 0,
     failed: 0,
-    skipped: 0,
-    get total(){ return this.passed + this.failed + this.skipped }
+    skipped: 0
   }
 
   const tableHeader = [
@@ -30,7 +29,7 @@ export default async function* githubSummaryReporter(source) {
     { data: 'Duration', header: true }
   ]
 
-  const reportDetails = testDetails(statistics, {tests: tests});    
+  const reportDetails = testDetails(statistics, {tests: tests})
 
   const tableRow = [
     `${statistics.passed}`,
@@ -56,25 +55,28 @@ function testDetails(statistics, test) {
 
   return test.tests
     .map(test =>
-      formatDetails(`${statusEmoji(test)} ${test.name}`, testDetails(statistics, test))
+      formatDetails(
+        `${statusEmoji(test)} ${test.name}`,
+        testDetails(statistics, test)
+      )
     )
     .join('\n')
 }
 
 function formatMessage(statistics, test) {
   if (test.skip) {
-    statistics.skipped++;
+    statistics.skipped++
     return 'Test skipped'
   }
 
   const error = test.error || test.failure
   if (!error) {
-    statistics.passed++;
+    statistics.passed++
     return 'Test passed'
   }
-  statistics.failed++;
+  statistics.failed++
 
-  let errorMessage = "\n\n\`\`\`\n" + error.message + "\n\`\`\`";
+  let errorMessage = '\n\n```\n' + error.message + '\n```'
 
   if (test.diagnostic) {
     errorMessage += `\n\n${test.diagnostic}`
@@ -90,7 +92,7 @@ function formatMessage(statistics, test) {
     }
   }
 
-  return errorMessage;
+  return errorMessage
 }
 
 function formatDetails(heading, content) {

--- a/test/resources/expected.md
+++ b/test/resources/expected.md
@@ -1,10 +1,14 @@
 <h2>Node.js Test Results</h2>
-<table><tr><th>Passed</th><th>Failed</th><th>Skipped</th><th>Duration</th></tr><tr><td>1</td><td>2</td><td>0</td><td>161ms</td></tr></table>
+<table><tr><th>Passed</th><th>Failed</th><th>Skipped</th><th>Duration</th></tr><tr><td>1</td><td>2</td><td>1</td><td>161ms</td></tr></table>
 <h3>Details</h3>
 <details>
   <summary>:x: calls a nonexistent method</summary>
   <blockquote>
-    nonexistentMethod is not defined
+    
+
+```
+nonexistentMethod is not defined
+```
 
 Stack:
 ```
@@ -31,10 +35,14 @@ TestContext.<anonymous> (file://test/resources/sample-tests/broken.test.js:5:3)
 <details>
   <summary>:x: fails</summary>
   <blockquote>
-    Expected values to be strictly equal:
+    
+
+```
+Expected values to be strictly equal:
 
 1 !== 2
 
+```
 
 Stack:
 ```


### PR DESCRIPTION
1. Recursively count all subtests for run statistics. I'm using a lot of suites (full of tests) and nested subtests, none of which currently register individually. As a result, the `tests passed`/`tests failed` are not helpful because they only count the top level suites. 
Example: One suite contains 20 subtests. The summary count only considers this to be one test. So if just one subtest fails, the result is success/failures: 0/1.
With my change it would be 19/1.

2. wrap errorMessage in backtick-blockquotes because of the peculiar format of assert.deepEqual message: It lists the comparison with `+actual -expected` line by line. If not escaped, both will be rendered as markdown and turn to bullet points which makes the assertion illegible

resolves #269 
resolves #270

Edit - message of assert.deepEqual after my changes:
![grafik](https://github.com/user-attachments/assets/80b2b411-7b45-4a16-9e56-39b6c47b2ef4)
