### PR TITLE
fix: strip leading slash from file paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,5 +136,8 @@ export function getSafePath(path) {
 
 export function getRelativeFilePath(path) {
   const filePath = getSafePath(path)
-  return new URL(filePath).pathname.replace(workspacePrefixRegex, '')
+  // Strip leading slash to to ensure GitHub displays the annotation: https://github.com/nearform/node-test-github-reporter/issues/286
+  return new URL(filePath).pathname
+    .replace(workspacePrefixRegex, '')
+    .replace(/^\//, '')
 }

--- a/test/package-tests/path.test.js
+++ b/test/package-tests/path.test.js
@@ -16,8 +16,8 @@ describe('File Path', () => {
   })
 
   it('should not error with file path without file:// prefix', () => {
-    const filePath = '/path/to/file.js'
-    const actualUrl = getRelativeFilePath(filePath)
-    assert.equal(actualUrl, filePath)
+    const expected = 'path/to/file.js'
+    const actualUrl = getRelativeFilePath('/path/to/file.js')
+    assert.equal(actualUrl, expected)
   })
 })


### PR DESCRIPTION
Fixes https://github.com/nearform/node-test-github-reporter/issues/286

Strip leading slash from file paths to ensure annotations show up in the GitHub UI.